### PR TITLE
Update: Use actions/checkout@v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:    
       - name: Clone project
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - uses: leafo/gh-actions-lua@v8.0.0
 


### PR DESCRIPTION
GitHub Actions checkout is at version 4. Use this as I believe any older version lower than v3 will not work past March 1st 2025.